### PR TITLE
Add editable default expensa amount

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2214,6 +2214,23 @@ class App(tk.Tk):
 
         ttk.Label(parent, text='Expensas', style='Title.TLabel').pack(pady=10)
 
+        default_amt = storage.load_expensa_default()
+        top = ttk.Frame(parent)
+        top.pack(pady=(0, 10))
+        ttk.Label(top, text='Monto por defecto:', style='Field.TLabel').grid(row=0, column=0, padx=5)
+        entry_def = ttk.Entry(top, style='Field.TEntry', width=12)
+        entry_def.grid(row=0, column=1, padx=5)
+        entry_def.insert(0, str(default_amt))
+        def _save_def():
+            try:
+                val = float(entry_def.get())
+            except ValueError:
+                messagebox.showerror('Error', 'Monto inválido')
+                return
+            storage.save_expensa_default(val)
+            messagebox.showinfo('Listo', 'Monto por defecto actualizado')
+        ttk.Button(top, text='Guardar', command=_save_def, style='Big.TButton').grid(row=0, column=2, padx=5)
+
         full_path = os.path.join(ensure_data_directory(), 'expensas.txt')
         regs = storage.load_expensas()
         # [(cuenta, fecha, monto), ...]

--- a/import_liquidaciones_energia.py
+++ b/import_liquidaciones_energia.py
@@ -95,3 +95,5 @@ if __name__ == "__main__":
             "No se encontró el archivo ODS:\n"
             f"  {ruta_ods}\n"
             "Indique la ruta como argumento al ejecutar el script.")
+    else:
+        importar_liquidaciones_desde_ods(ruta_ods)

--- a/storage.py
+++ b/storage.py
@@ -177,6 +177,7 @@ def save_tax_pagos(tax_tuple):
 # --- Expensas -------------------------------------------------
 
 EXPENSAS_FILE = 'expensas.txt'
+EXPENSA_DEFAULT_FILE = 'expensa_default.txt'
 
 def load_expensas():
     """Return list of tuples [(cuenta, fecha, monto), ...]"""
@@ -207,6 +208,23 @@ def save_expensas(exp_list):
             f.write(repr((cuenta, fecha, monto)) + "\n")
     return True
 
+def load_expensa_default():
+    """Return the default monthly amount for new expensa entries."""
+    path = os.path.join(ensure_data_directory(), EXPENSA_DEFAULT_FILE)
+    if os.path.exists(path):
+        try:
+            return float(open(path, 'r', encoding='utf-8').read().strip())
+        except Exception:
+            pass
+    return 33900.0
+
+
+def save_expensa_default(value):
+    path = os.path.join(ensure_data_directory(), EXPENSA_DEFAULT_FILE)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(str(float(value)))
+    return True
+
 def update_expensas(plan_dict):
     """Add a new positive entry each month for every expensa account."""
     exps = load_expensas()
@@ -220,12 +238,13 @@ def update_expensas(plan_dict):
         mes = fecha[:7]
         last_months[c] = max(mes, last_months.get(c, '0000-00'))
 
+    default_amt = load_expensa_default()
     for acc in plan_dict:
         if not str(acc).startswith('11-21-'):
             continue
         last = last_months.get(acc)
         if last != cur_month:
-            exps.append((str(acc), cur_month, 33900.0))
+            exps.append((str(acc), cur_month, default_amt))
             updated = True
     if updated:
         save_expensas(exps)


### PR DESCRIPTION
## Summary
- let users set default monthly expensa value
- store default amount in `expensa_default.txt`
- use the value when generating monthly expensas

## Testing
- `python -m py_compile cli.py storage.py import_liquidaciones_energia.py`
- `python import_liquidaciones_energia.py 'LIQUIDACIONES ENERGIA.ods'`


------
https://chatgpt.com/codex/tasks/task_e_6851c6d4b7fc83298b09afc56a07558e